### PR TITLE
Modified for the fatal errors on a staticcheck verification.

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -2,6 +2,7 @@ package sigctx
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"runtime"
 	"sync"
@@ -26,7 +27,7 @@ func TestWithSignals(t *testing.T) {
 		time.Sleep(time.Millisecond * 100)
 		p, err := os.FindProcess(pid)
 		if err != nil {
-			t.Fatal("Failed to get pid")
+			panic(fmt.Sprint("Failed to get pid"))
 		}
 		if err := p.Signal(syscall.SIGUSR1); err != nil {
 			t.Error(err.Error())
@@ -106,7 +107,7 @@ func TestWithCancelSignals(t *testing.T) {
 		time.Sleep(time.Millisecond * 200)
 		p, err := os.FindProcess(pid)
 		if err != nil {
-			t.Fatal("Failed to get pid")
+			panic(fmt.Sprint("Failed to get pid"))
 		}
 		p.Signal(syscall.SIGUSR1)
 		time.Sleep(time.Second * 3)


### PR DESCRIPTION
## Overview
With staticcheck command, the fatal errors on `context_test` appears on a console. 
```
$ staticcheck
context_test.go:25:2: the goroutine calls T.Fatal, which must be called in the same goroutine as the test (SA2002)
context_test.go:105:2: the goroutine calls T.Fatal, which must be called in the same goroutine as the test (SA2002)
```

So changed not to use t.Fatal as fatal case of `goroutine`

## Reference

https://github.com/prometheus/node_exporter/pull/439/files